### PR TITLE
Don't require Copy for StateMachineTransition

### DIFF
--- a/little_raft/src/message.rs
+++ b/little_raft/src/message.rs
@@ -3,7 +3,7 @@ use crate::state_machine::StateMachineTransition;
 
 /// LogEntry is a state machine transition along with some metadata needed for
 /// Raft.
-#[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd)]
 pub struct LogEntry<T>
 where
     T: StateMachineTransition,

--- a/little_raft/src/replica.rs
+++ b/little_raft/src/replica.rs
@@ -12,7 +12,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 enum State {
     Follower,
     Candidate,
@@ -143,9 +143,9 @@ where
             log: vec![LogEntry {
                 term: 0,
                 index: 0,
-                transition: noop_transition,
+                transition: noop_transition.clone(),
             }],
-            noop_transition: noop_transition,
+            noop_transition: noop_transition.clone(),
             commit_index: 0,
             last_applied: 0,
             next_index: BTreeMap::new(),
@@ -351,7 +351,7 @@ where
         while self.commit_index > self.last_applied {
             self.last_applied += 1;
             let mut state_machine = self.state_machine.lock().unwrap();
-            state_machine.apply_transition(self.log[self.last_applied].transition);
+            state_machine.apply_transition(self.log[self.last_applied].transition.clone());
             state_machine.register_transition_state(
                 self.log[self.last_applied].transition.get_id(),
                 TransitionState::Applied,
@@ -367,7 +367,7 @@ where
             if self.state == State::Leader {
                 self.log.push(LogEntry {
                     index: self.log.len(),
-                    transition: transition,
+                    transition: transition.clone(),
                     term: self.current_term,
                 });
 
@@ -674,7 +674,7 @@ where
         // in the part 8 of the paper.
         self.log.push(LogEntry {
             index: self.log.len(),
-            transition: self.noop_transition,
+            transition: self.noop_transition.clone(),
             term: self.current_term,
         });
     }

--- a/little_raft/src/state_machine.rs
+++ b/little_raft/src/state_machine.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 /// TransitionState describes the state of a particular transition.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum TransitionState {
     /// Queued transitions have been received from the user but have not been
     /// processed yet. They are in the queue.
@@ -20,7 +20,7 @@ pub enum TransitionState {
 
 /// StateMachineTransition describes a user-defined transition that can be
 /// applied to the state machine replicated by Raft.
-pub trait StateMachineTransition: Copy + Clone + Debug {
+pub trait StateMachineTransition: Clone + Debug {
     /// TransitionID is used to identify the transition.
     type TransitionID: Eq;
 

--- a/little_raft/tests/raft_stable.rs
+++ b/little_raft/tests/raft_stable.rs
@@ -16,7 +16,7 @@ const MAX_ELECTION_TIMEOUT: Duration = Duration::from_millis(950);
 
 // Our state machine will carry out simple plus and minus operations on a
 // number, starting from zero.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 struct ArithmeticOperation {
     id: usize,
     delta: i32,
@@ -288,6 +288,7 @@ fn run_replicas() {
     let state_machines = create_state_machines(n, applied_transitions_tx);
     let (message_tx, transition_tx, message_rx, transition_rx) = create_notifiers(n);
     for i in 0..n {
+        let noop = noop.clone();
         let local_peer_ids = peer_ids[i].clone();
         let cluster = clusters[i].clone();
         let state_machine = state_machines[i].clone();

--- a/little_raft/tests/raft_unstable.rs
+++ b/little_raft/tests/raft_unstable.rs
@@ -16,7 +16,7 @@ const MAX_ELECTION_TIMEOUT: Duration = Duration::from_millis(950);
 
 // Our state machine will carry out simple plus and minus operations on a
 // number, starting from zero.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 struct ArithmeticOperation {
     id: usize,
     delta: i32,
@@ -288,6 +288,7 @@ fn run_replicas() {
     let state_machines = create_state_machines(n, applied_transitions_tx);
     let (message_tx, transition_tx, message_rx, transition_rx) = create_notifiers(n);
     for i in 0..n {
+        let noop = noop.clone();
         let local_peer_ids = peer_ids[i].clone();
         let cluster = clusters[i].clone();
         let state_machine = state_machines[i].clone();


### PR DESCRIPTION
Heap-allocated things like Strings and Vecs are not copyable so don't
require Copy trait for StateMachineTransition to simplify state machine
transition implementation.