### PR TITLE
Addressing a prev_log_index bug

### DIFF
--- a/little_raft/src/message.rs
+++ b/little_raft/src/message.rs
@@ -41,6 +41,7 @@ where
         term: usize,
         success: bool,
         last_index: usize,
+        mismatch_index: Option<usize>,
     },
 
     /// VoteRequest is used by Candidates to solicit votes for themselves.


### PR DESCRIPTION
Addressing an issue where when next_index for a
peer is discovered to be 0, the heartbeat message sending call
of the leader will panic when trying to set prev_log_index to -1.
Fix by setting prev_log_index to 0 when next_index is 0.