### PR TITLE
Addressing mismatch_index being None

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
 
 [[package]]
 name = "little_raft"
-version = "0.1.3"
+version = "0.1.5"
 dependencies = [
  "crossbeam",
  "crossbeam-channel",

--- a/little_raft/Cargo.toml
+++ b/little_raft/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "The lightest distributed consensus library. Run your own replicated state machine!"
 name = "little_raft"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Ilya Andreev <iandre3@illinois.edu>"]
 edition = "2018"
 license = "MIT"

--- a/little_raft/src/replica.rs
+++ b/little_raft/src/replica.rs
@@ -413,10 +413,11 @@ where
                     // to the Raft paper's guidance on decreasing next_index by
                     // one at a time, but is more performant in cases when we
                     // can cut straight to the follower's last_index+1.
-                    let mismatch_index = mismatch_index.unwrap();
-                    if mismatch_index < self.next_index[&from_id] {
-                        let next_index = cmp::min(mismatch_index, last_index + 1);
-                        self.next_index.insert(from_id, next_index);
+                    if let Some(mismatch_index) = mismatch_index {
+                        if mismatch_index < self.next_index[&from_id] {
+                            let next_index = cmp::min(mismatch_index, last_index + 1);
+                            self.next_index.insert(from_id, next_index);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The only way a panic on line 419 can occur is if all of the following is true:
- the leader gets a response with success: false
- the response was sent due to the leader's term being behind the follower's term
- the leader itself is no longer behind the follower's term

If the message takes too long to deliver (for example while the same leader gets re-elected), the leader theoretically might have enough time to advance ahead of the term specified in the follower's term. In this case Little Raft panics. Let's not panic by checking that mismatch_index is set to Some(...), and if not, ignore the follower's response.

Closes #22 