### PR TITLE
Broadcast new transitions immediately, not waiting for heartbeat timer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
 
 [[package]]
 name = "little_raft"
-version = "0.1.3"
+version = "0.1.6"
 dependencies = [
  "crossbeam",
  "crossbeam-channel",

--- a/little_raft/Cargo.toml
+++ b/little_raft/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "The lightest distributed consensus library. Run your own replicated state machine!"
 name = "little_raft"
-version = "0.1.4"
+version = "0.1.6"
 authors = ["Ilya Andreev <iandre3@illinois.edu>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
Raft Leader doesn't have to wait for the heartbeat timer to broadcast a pending transition. Let's broadcast as soon as transitions are queued up.

Closes #24 